### PR TITLE
Correction label name for stork-scheduler

### DIFF
--- a/k8s/portworx.yaml
+++ b/k8s/portworx.yaml
@@ -242,7 +242,7 @@ spec:
       labels:
         component: scheduler
         tier: control-plane
-      name: stork-scheduler
+        name: stork-scheduler
     spec:
       containers:
       - command:


### PR DESCRIPTION
Correction of bad indentation on name label for stork-scheduler that was causing a non-interpretation of the label